### PR TITLE
fix: bartender url

### DIFF
--- a/nvfetcher.toml
+++ b/nvfetcher.toml
@@ -15,7 +15,7 @@ fetch.url = "https://github.com/zen-browser/desktop/releases/download/twilight-1
 [bartender-6]
 #src.manual = 'B2'
 src.manual = "6-0-0"
-fetch.url = "https://macbartender.com/B2/updates/$ver/Bartender%206.dmg"
+fetch.url = "https://downloads.macbartender.com/B2/updates/B6Latest/Bartender%206.dmg"
 url.name = "Bartender6.dmg"
 [yabai]
 src.github = "koekeishiya/yabai"


### PR DESCRIPTION
saw your Update source and create PR workflow was failing. looks like bartender fetch url needed updating.
